### PR TITLE
Fix cmd error (not rails s but bundle exec rails s to start Redmine.)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,9 @@ RUN gem update bundler
 RUN bundle config set without 'postgresql rmagick mysql'
 RUN bundle install
 RUN bundle exec rake db:migrate && bundle exec rake generate_secret_token
+RUN bundle exec rails runner public/themes/redmine_theme_kodomo_midori/miscs/sample.rb
 
 WORKDIR /app/redmine
 
 EXPOSE  3000
-CMD ["rails", "server", "-b", "0.0.0.0"]
+CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
   web:
     build:
       context: .
-    image: redmine_sqlite3
-    container_name: redmine_sqlite3
+    image: redmine_theme_kodomo_midori
+    container_name: redmine_theme_kodomo_midori
     command: >
       bash -c "bundle &&
            bundle exec rake db:migrate &&


### PR DESCRIPTION
Related: #1 

**Before**

- docker run is failed because rails not found.
- CMD rails s だと、bundlerを使ってインストールしているのでrailsがうまく上がりません
- 明示的に bundle exec rails sで起動するように変更しました

**More**

- Applied this theme at first!
- You can see this theme just after accessing Redmine.
- マイグレーション後にスクリプトを流し込んでテーマが当たった状態で起動するようにしました

```bash

# build
docker build -t redmine_theme_kodomo_midori_container:latest .

# run
docker run --rm -d -p 3000:3000/tcp redmine_theme_kodomo_midori_container:latest
```