### PR TITLE
Hide speech bubbles in the issue history when Gravatar is enabled

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -373,7 +373,7 @@ div[id^="change-"]:nth-of-type(odd) {
   margin-right: 30px;
 }
 
-h4.note-header::before {
+.avatars-off h4.note-header::before {
   content: "┥";
   font-size: 12pt;
   top: 6px;


### PR DESCRIPTION
Before:
![speech-bubble-before](https://user-images.githubusercontent.com/114863/81299585-636e3700-90b1-11ea-98b2-c8f8f06ff966.png)

After:
![speech-bubble-after](https://user-images.githubusercontent.com/114863/81299613-6c5f0880-90b1-11ea-9108-39af709c78ff.png)
